### PR TITLE
feat/swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,84 @@
-# "Ambasada za urbanizam" project
 
-Django DRF backend for website 
+# Проект "Ambasada za urbanizam"
+Backend на Django DRF для веб-сайта.
 
+## 🛠️ Локальная разработка с Docker
 
-## 🛠️ Local Development with Docker
+### Настройка окружения:
 
-### Environment Setup:
 ```shell
-  cp .env.example .env
+cp  .env.example  .env
 ```
 
-### Start services.
+### Запуск сервисов.
 
-_If there are no local  `docker images` - they will be pulled from DockerHub or builded._
+*Если локальных `docker images` нет — они будут загружены из DockerHub или собраны автоматически.*
 ```shell
-  docker compose up -d
+docker  compose  up  -d
 ```
 
-### 3. Apply database migrations and create superuser:
-```shell
-  docker compose exec -it web python backend/manage.py migrate
-  docker compose exec -it web python backend/manage.py createsuperuser
-```
-### Access Application
-- Open [http://localhost:8000/api/docs/](http://localhost:8000/api/docs/) in browser
+### 3. Применить миграции базы данных и создать суперпользователя:
 
-## ✅ Check code Quality and formatting
-
-Format code:
 ```shell
-docker compose run --rm -it web ruff format
+docker  compose  exec  -it  web  python  backend/manage.py  migrate
+docker  compose  exec  -it  web  python  backend/manage.py  createsuperuser
 ```
 
-Make all checks and tests like in production deploy:
-```shell
-docker compose run --rm -it web bash ./docker/django/ci.sh
+### Доступ к приложению
+
+* Откройте http://localhost:8000/api/docs/ в браузере
+
+## API
+
+Документация API доступна по следующим адресам:
+*  `/api/docs/` → Swagger UI
+
+*  `/api/redoc/` → ReDoc
+
+*  `/api/schema/` → raw schema (OpenAPI)
+
+### Примечания
+
+Документация генерируется автоматически на основе **DRF views и serializers**.
+При добавлении новых endpoints они автоматически появляются в **OpenAPI schema** и документации.
+
+### Поддержка многоязычности
+
+При добавлении нового функционала необходимо учитывать поддержку многоязычности.
+* Используйте `gettext_lazy` для строк, которые должны поддерживать перевод:
+
+```python
+from django.utils.translation import gettext_lazy as _
 ```
 
+* Язык определяется через HTTP-заголовок `Accept-Language`.
+* Руководство по мультиязычности - https://disk.yandex.ru/i/2c5tOXhtRHoKUQ
+  
+## ✅ Проверка качества и форматирования кода
 
-## 🔄 Maintenance Commands
-Rebuild Container (when requirements change or  some issues occur):
+Форматирование кода:
 
 ```shell
-docker compose build web
-docker compose up -d
+docker  compose  run  --rm  -it  web  ruff  format
 ```
 
-Clean Project (removes volumes including database):
+Запуск всех проверок и тестов так же, как при production-деплое:
+
 ```shell
-docker compose down -v
+docker  compose  run  --rm  -it  web  bash  ./docker/django/ci.sh
+```
+
+## 🔄 Команды обслуживания
+
+Пересборка контейнера (если изменились зависимости или возникли проблемы):
+
+```shell
+docker  compose  build  web
+docker  compose  up  -d
+```
+
+Очистка проекта (удаляет volumes, включая базу данных):
+
+```shell
+docker  compose  down  -v
 ```

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,3 +1,16 @@
+from django.urls import path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
+
 app_name = 'api'
 
-urlpatterns = []
+doc_urlpatterns = [
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('docs/', SpectacularSwaggerView.as_view(url_name='api:schema'), name='swagger'),
+    path('redoc/', SpectacularRedocView.as_view(url_name='api:schema'), name='redoc'),
+]
+
+urlpatterns = [] + doc_urlpatterns

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -261,3 +261,10 @@ LOGGING = {
         },
     },
 }
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Backend API',
+    'DESCRIPTION': 'API documentation',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}


### PR DESCRIPTION
Добавлена интеграция Swagger (drf-spectacular) для автоматической генерации OpenAPI документации API.

**Что сделано:**

- Подключён drf-spectacular
- Добавлены endpoints:
- /api/schema/ — OpenAPI схема
- /api/docs/ — Swagger UI
- /api/redoc/ — ReDoc UI
- Настроен DEFAULT_SCHEMA_CLASS в DRF
- Добавлены базовые настройки SPECTACULAR_SETTINGS

**Как проверить:**
Запустить проект
Перейти:
**/api/docs/** → Swagger UI
**/api/redoc/** → ReDoc
**/api/schema/** → raw schema

**Примечания:**
Документация генерируется автоматически на основе DRF views/serializers
При добавлении новых endpoints они автоматически появятся в schema