### PR TITLE
feat(security): add security policy — CSP, HSTS, throttling, validators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,6 @@ PGUSER=postgres
 # REDIS & CACHE
 # ====================
 REDIS_URL=redis://redis:6379/0
-CACHE_BACKEND=django_redis.cache.RedisCache
 CACHE_LOCATION=redis://redis:6379/
 
 # ====================

--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,8 @@ PGUSER=postgres
 # REDIS & CACHE
 # ====================
 REDIS_URL=redis://redis:6379/0
-CACHE_BACKEND=django.core.cache.backends.locmem.LocMemCache
-#CACHE_BACKEND=django_redis.cache.RedisCache
-CACHE_LOCATION=
-#CACHE_LOCATION=redis://redis:6379/
+CACHE_BACKEND=django_redis.cache.RedisCache
+CACHE_LOCATION=redis://redis:6379/
 
 # ====================
 # CELERY

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,11 @@ SECRET_KEY=your-production-secret-key-change-this-now
 DJANGO_SETTINGS_MODULE=backend.settings
 ALLOWED_HOSTS=localhost,127.0.0.1,[::1]
 CSRF_TRUSTED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000,http://0.0.0.0:8000
+# CORS — Frontend domen
+# DEV:
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://0.0.0.0:3000
+# PRODUCTION:
+# CORS_ALLOWED_ORIGINS=https://ambasada.rs,https://www.ambasada.rs
 
 # ====================
 # DATABASE
@@ -25,8 +29,10 @@ PGUSER=postgres
 # REDIS & CACHE
 # ====================
 REDIS_URL=redis://redis:6379/0
-CACHE_BACKEND=django_redis.cache.RedisCache
-CACHE_LOCATION=redis://redis:6379/
+CACHE_BACKEND=django.core.cache.backends.locmem.LocMemCache
+#CACHE_BACKEND=django_redis.cache.RedisCache
+CACHE_LOCATION=
+#CACHE_LOCATION=redis://redis:6379/
 
 # ====================
 # CELERY

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,0 +1,29 @@
+"""
+...
+
+Anti-spam techniques (for public forms):
+
+    Honeypot field — hidden via CSS (display: none), NOT type="hidden".
+    Bots fill all visible fields automatically; humans never touch it.
+    If the field arrives non-empty — silently reject the submission.
+
+    class ContactSerializer(serializers.Serializer):
+        # Regular fields...
+
+        website = serializers.CharField(
+            required=False,
+            allow_blank=True,
+            write_only=True,  # never returned in response
+        )
+
+        def validate_website(self, value):
+            if value and value.strip():
+                raise serializers.ValidationError('Invalid submission.')
+            return value
+
+    Frontend (React/Vue/vanilla):
+        <input name="website" style="display:none" tabindex="-1" autocomplete="off" />
+        # Never fill it programmatically — must stay empty on submit.
+
+...
+"""

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -23,8 +23,6 @@ APP_ENV = config('APP_ENV', default='development')
 if APP_ENV == 'production':
     DEBUG = False
 
-
-
     CSRF_COOKIE_HTTPONLY = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     # Content Security Policy
@@ -124,7 +122,7 @@ if 'redis' in CACHE_LOCATION:
         'default': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': CACHE_LOCATION,
-            'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'}
+            'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'},
         }
     }
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -23,16 +23,9 @@ APP_ENV = config('APP_ENV', default='development')
 if APP_ENV == 'production':
     DEBUG = False
 
-    # Cookies
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
-    SESSION_COOKIE_HTTPONLY = True
+
+
     CSRF_COOKIE_HTTPONLY = True
-    SESSION_COOKIE_SAMESITE = 'Lax'
-    CSRF_COOKIE_SAMESITE = 'Lax'
-    X_FRAME_OPTIONS = 'DENY'
-    SECURE_CONTENT_TYPE_NOSNIFF = True
-    SECURE_REFERRER_POLICY = 'same-origin'
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     # Content Security Policy
     CSP_DEFAULT_SRC = ("'self'",)
@@ -42,12 +35,10 @@ if APP_ENV == 'production':
     CSP_FONT_SRC = ("'self'",)
     CSP_CONNECT_SRC = ("'self'",)
     CSP_FRAME_ANCESTORS = ("'none'",)
+    # SSL redirect is disabled because Caddy handles HTTPS termination
     SECURE_SSL_REDIRECT = False
-    # HSTS is managed by Caddy — Django must not add its own header.
-    # Set to 0 to disable. Change to 31536000 only if Django terminates TLS directly.
-    SECURE_HSTS_SECONDS = 0
-    SECURE_HSTS_INCLUDE_SUBDOMAINS = False
-    SECURE_HSTS_PRELOAD = False
+    # HSTS is managed by Caddy — Django must not add its own header
+    # SECURE_HSTS_SECONDS = 0 (default)
 
 SESSION_COOKIE_NAME = 'ambasada_sessionid'
 CSRF_COOKIE_NAME = 'ambasada_csrftoken'
@@ -126,16 +117,16 @@ MIDDLEWARE = [
 ROOT_URLCONF = 'backend.urls'
 
 # Cache — Redis
-CACHE_BACKEND = config('CACHE_BACKEND', default='django.core.cache.backends.locmem.LocMemCache')
+CACHE_LOCATION = config('CACHE_LOCATION', default='')
 
-CACHES = {
-    'default': {
-        'BACKEND': CACHE_BACKEND,
-        'LOCATION': config('CACHE_LOCATION', default=''),
-        # OPTIONS только для Redis
-        **({'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'}} if 'redis' in CACHE_BACKEND else {}),
+if 'redis' in CACHE_LOCATION:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': CACHE_LOCATION,
+            'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'}
+        }
     }
-}
 
 TEMPLATES = [
     {
@@ -226,10 +217,6 @@ LOCALE_PATHS = ['/var/www/django/locale' if APP_ENV == 'production' else str(BAS
 
 TIME_ZONE = 'Europe/Moscow'
 
-USE_I18N = True
-
-USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
@@ -247,10 +234,6 @@ STATIC_ROOT = '.static' if _COLLECTSTATIC_DRYRUN else '/var/www/django/static'
 MEDIA_URL = 'media/'
 MEDIA_ROOT = '/var/www/django/media' if APP_ENV == 'production' else str(BASE_DIR / 'media')
 
-# File upload limit
-DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB
-FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB — up to this size is stored in memory
-
 
 # REST Framework
 REST_FRAMEWORK = {
@@ -263,11 +246,6 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_RENDERER_CLASSES': [
         'rest_framework.renderers.JSONRenderer',
-    ],
-    'DEFAULT_PARSER_CLASSES': [
-        'rest_framework.parsers.JSONParser',
-        'rest_framework.parsers.FormParser',
-        'rest_framework.parsers.MultiPartParser',
     ],
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',
@@ -288,7 +266,6 @@ REST_FRAMEWORK = {
         'contact': '5/hour',  # форма обратной связи
         'auth': '10/minute',  # вход в Admin — защита от brute-force
     },
-    'DEFAULT_CONTENT_NEGOTIATION_CLASS': 'rest_framework.negotiation.DefaultContentNegotiation',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'COERCE_DECIMAL_TO_STRING': False,

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -23,12 +23,68 @@ APP_ENV = config('APP_ENV', default='development')
 if APP_ENV == 'production':
     DEBUG = False
 
+    # Cookies
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_HTTPONLY = True
+    CSRF_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = 'Lax'
+    CSRF_COOKIE_SAMESITE = 'Lax'
+    X_FRAME_OPTIONS = 'DENY'
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_REFERRER_POLICY = 'same-origin'
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    # Content Security Policy
+    CSP_DEFAULT_SRC = ("'self'",)
+    CSP_SCRIPT_SRC = ("'self'",)
+    CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
+    CSP_IMG_SRC = ("'self'", 'data:')
+    CSP_FONT_SRC = ("'self'",)
+    CSP_CONNECT_SRC = ("'self'",)
+    CSP_FRAME_ANCESTORS = ("'none'",)
+    SECURE_SSL_REDIRECT = False
+    # HSTS is managed by Caddy — Django must not add its own header.
+    # Set to 0 to disable. Change to 31536000 only if Django terminates TLS directly.
+    SECURE_HSTS_SECONDS = 0
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+    SECURE_HSTS_PRELOAD = False
+
+SESSION_COOKIE_NAME = 'ambasada_sessionid'
+CSRF_COOKIE_NAME = 'ambasada_csrftoken'
+
 
 ALLOWED_HOSTS = config(
     'ALLOWED_HOSTS',
     cast=lambda v: [s.strip() for s in v.split(',')],
     default='localhost,127.0.0.1',
 )
+
+# CORS
+CORS_ALLOWED_ORIGINS = config(
+    'CORS_ALLOWED_ORIGINS',
+    cast=lambda v: [s.strip() for s in v.split(',')],
+    default='http://localhost:3000',
+)
+
+CORS_ALLOW_CREDENTIALS = False
+
+# Allowed headers - adding Accept-Language for localization
+CORS_ALLOW_HEADERS = [
+    'accept',
+    'accept-encoding',
+    'accept-language',  # needed for i18n, the front transmits the language
+    'content-type',
+    'authorization',
+    'x-csrftoken',
+    'x-requested-with',
+]
+
+# Permitted methods are only those that are actually used.
+CORS_ALLOW_METHODS = [
+    'GET',
+    'POST',  # for /contact
+    'OPTIONS',  # preflight
+]
 
 
 # Application definition
@@ -55,7 +111,10 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'csp.middleware.CSPMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'core.middleware.AdminLoginThrottleMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -65,6 +124,18 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'backend.urls'
+
+# Cache — Redis
+CACHE_BACKEND = config('CACHE_BACKEND', default='django.core.cache.backends.locmem.LocMemCache')
+
+CACHES = {
+    'default': {
+        'BACKEND': CACHE_BACKEND,
+        'LOCATION': config('CACHE_LOCATION', default=''),
+        # OPTIONS только для Redis
+        **({'OPTIONS': {'CLIENT_CLASS': 'django_redis.client.DefaultClient'}} if 'redis' in CACHE_BACKEND else {}),
+    }
+}
 
 TEMPLATES = [
     {
@@ -176,6 +247,11 @@ STATIC_ROOT = '.static' if _COLLECTSTATIC_DRYRUN else '/var/www/django/static'
 MEDIA_URL = 'media/'
 MEDIA_ROOT = '/var/www/django/media' if APP_ENV == 'production' else str(BASE_DIR / 'media')
 
+# File upload limit
+DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB
+FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10 MB — up to this size is stored in memory
+
+
 # REST Framework
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
@@ -183,7 +259,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_RENDERER_CLASSES': [
         'rest_framework.renderers.JSONRenderer',
@@ -204,10 +280,13 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
         'rest_framework.throttling.UserRateThrottle',
+        'rest_framework.throttling.ScopedRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100/day',
-        'user': '1000/day',
+        'anon': '120/hour',
+        'user': '600/hour',
+        'contact': '5/hour',  # форма обратной связи
+        'auth': '10/minute',  # вход в Admin — защита от brute-force
     },
     'DEFAULT_CONTENT_NEGOTIATION_CLASS': 'rest_framework.negotiation.DefaultContentNegotiation',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
@@ -215,7 +294,6 @@ REST_FRAMEWORK = {
     'COERCE_DECIMAL_TO_STRING': False,
 }
 
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 LOGGING = {
     'version': 1,
@@ -231,33 +309,45 @@ LOGGING = {
         },
     },
     'handlers': {
+        # Always active — writes to stdout in both dev and production
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'console',
-            'filters': ['require_debug_false'],
             'level': 'DEBUG',
         },
+        # Production only — writes WARNING+ to file
         'file': {
             'class': 'logging.FileHandler',
             'formatter': 'console',
             'filters': ['require_debug_false'],
-            'level': 'INFO',
+            'level': 'WARNING',
             'filename': 'debug.log',
         },
     },
     'loggers': {
+        # Django internals
         'django': {
             'handlers': ['console'],
             'level': 'INFO',
-            'propagate': True,
+            'propagate': False,
         },
+        # SQL queries — INFO to avoid flooding in dev, switch to DEBUG when needed
         'django.db.backends': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
+            'propagate': False,
         },
+        # Email sending — useful to trace in both dev and production
         'django.core.mail': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
+        },
+        # Security events: admin brute-force, honeypot, invalid form attempts
+        'security': {
+            'handlers': ['console', 'file'],
+            'level': 'WARNING',
+            'propagate': False,
         },
     },
 }

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,0 +1,53 @@
+import logging
+
+from django.core.cache import cache
+from django.http import HttpResponse
+
+security_logger = logging.getLogger('security')
+
+
+class AdminLoginThrottleMiddleware:
+    """
+    Limits the number of login attempts to Django Admin.
+
+    10 attempts per minute from a single IP address, then a 5-minute lockout.
+    """
+
+    MAX_ATTEMPTS = 10
+    WINDOW_SECONDS = 60  # attempt counting window
+    BLOCK_SECONDS = 300  # blocking time after exceeding
+
+    def __init__(self, get_response):
+        """Initialize middleware with the next handler in the chain."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == '/admin/login/' and request.method == 'POST':
+            ip = self._get_ip(request)
+            block_key = f'admin_login_block:{ip}'
+            count_key = f'admin_login_count:{ip}'
+
+            # Checking the blocking
+            if cache.get(block_key):
+                security_logger.warning('Admin login blocked: IP=%s', ip)
+                return HttpResponse(
+                    'Too many login attempts. Try again later.',
+                    status=429,
+                )
+
+            # Count attempts
+            attempts = cache.get(count_key, 0) + 1
+            cache.set(count_key, attempts, self.WINDOW_SECONDS)
+
+            if attempts >= self.MAX_ATTEMPTS:
+                cache.set(block_key, True, self.BLOCK_SECONDS)
+                security_logger.warning('Admin login throttled: IP=%s, attempts=%d', ip, attempts)
+
+        return self.get_response(request)
+
+    @staticmethod
+    def _get_ip(request):
+        forwarded = request.META.get('HTTP_X_FORWARDED_FOR')
+        if forwarded:
+            return forwarded.split(',')[0].strip()
+        return request.META.get('REMOTE_ADDR', '0.0.0.0')

--- a/backend/core/validators.py
+++ b/backend/core/validators.py
@@ -1,0 +1,210 @@
+"""
+Core validators for text fields and media file uploads.
+
+Usage
+-----
+
+Text validators — connect in serializer fields:
+
+    from core.validators import validate_no_html, validate_no_urls
+
+    class ArticleSerializer(serializers.Serializer):
+        title = serializers.CharField(
+            validators=[validate_no_html],
+        )
+        message = serializers.CharField(
+            validators=[validate_no_html, validate_no_urls],
+        )
+
+Media validator — connect in model fields:
+
+    from core.validators import MediaFileValidator
+
+    class Project(BaseModel):
+        image = models.ImageField(
+            upload_to=upload_to_projects,
+            validators=[MediaFileValidator()],           # default: IMAGE_TYPES, 10 MB
+        )
+
+    # Custom MIME types or size limit:
+    from core.validators import MediaFileValidator, DOCUMENT_TYPES
+
+    class Report(BaseModel):
+        file = models.FileField(
+            upload_to=upload_to_reports,
+            validators=[MediaFileValidator(
+                allowed_types=DOCUMENT_TYPES,
+                max_size_mb=20,
+            )],
+        )
+
+Predefined MIME type sets:
+
+    IMAGE_TYPES          = ['image/jpeg', 'image/png', 'image/webp']
+    IMAGE_TYPES_EXTENDED = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/svg+xml']
+    DOCUMENT_TYPES       = ['application/pdf']
+
+Anti-spam for public forms — Honeypot pattern:
+
+    Honeypot is a hidden field (display: none via CSS, NOT type="hidden").
+    Legitimate users never see it. Bots fill all fields automatically — we reject them.
+
+    class ContactSerializer(serializers.Serializer):
+        # ... regular fields ...
+
+        website = serializers.CharField(
+            required=False,
+            allow_blank=True,
+            write_only=True,     # never returned in response
+        )
+
+        def validate_website(self, value):
+            if value and value.strip():
+                # Deliberately vague — bots should not learn what triggered rejection
+                raise serializers.ValidationError('Invalid submission.')
+            return value
+
+    Frontend markup (React / Vue / vanilla):
+        <input
+            name="website"
+            style="display:none"
+            tabindex="-1"
+            autocomplete="off"
+        />
+        # Important: never fill this field programmatically — it must arrive empty.
+"""
+
+import re
+
+import magic
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+# ---------------------------------------------------------------------------
+# Predefined MIME type sets
+# ---------------------------------------------------------------------------
+
+#: Standard web image formats. Use as default for ImageField validators.
+IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+
+#: Extended image set including GIF and SVG.
+IMAGE_TYPES_EXTENDED = [*IMAGE_TYPES, 'image/gif', 'image/svg+xml']
+
+#: PDF documents only.
+DOCUMENT_TYPES = ['application/pdf']
+
+
+# ---------------------------------------------------------------------------
+# Text validators
+# ---------------------------------------------------------------------------
+
+
+def validate_no_html(value: str) -> None:
+    """
+    Reject values containing HTML tags.
+
+    Protects against XSS when user input ends up in emails,
+    logs, or is rendered without escaping.
+
+    Example blocked input: <script>alert(1)</script>, <b>bold</b>
+    """
+    if re.search(r'<[^>]+>', value):
+        raise ValidationError(_('HTML tags are not allowed.'))
+
+
+def validate_no_urls(value: str) -> None:
+    """
+    Reject values containing HTTP/HTTPS links or bare www. addresses.
+
+    Filters out the majority of spam messages that contain
+    advertising or phishing links.
+
+    Example blocked input: https://spam.com, www.ads.net/promo
+    """
+    if re.search(r'(https?://|www\.)\S+', value, re.IGNORECASE):
+        raise ValidationError(_('Links in messages are not allowed.'))
+
+
+# ---------------------------------------------------------------------------
+# Media file validator
+# ---------------------------------------------------------------------------
+
+
+class MediaFileValidator:
+    """
+    Validate uploaded files by real MIME type (magic bytes) and size.
+
+    Reads the first 2048 bytes of the file to detect its true type —
+    independent of the file extension. This prevents MIME spoofing,
+    e.g. a PHP script renamed to photo.webp will be detected and rejected.
+
+    Implements __eq__ and deconstruct so Django can serialize
+    this validator into migrations without errors.
+
+    Args:
+        allowed_types:  List of accepted MIME type strings.
+                        Defaults to IMAGE_TYPES (jpeg, png, webp).
+        max_size_mb:    Maximum allowed file size in megabytes.
+                        Defaults to 10 MB.
+
+    Raises:
+        ValidationError: if the file's MIME type is not in allowed_types,
+                         or if the file size exceeds max_size_mb.
+    """
+
+    def __init__(
+        self,
+        allowed_types: list[str] | None = None,
+        max_size_mb: int = 10,
+    ) -> None:
+        """Initialize validator with allowed MIME types and maximum file size."""
+        self.allowed_types = allowed_types or IMAGE_TYPES
+        self.max_size_mb = max_size_mb
+        self._max_size_bytes = max_size_mb * 1024 * 1024
+
+    def __call__(self, file) -> None:
+        self._validate_size(file)
+        self._validate_mime(file)
+
+    def _validate_size(self, file) -> None:
+        if file.size > self._max_size_bytes:
+            raise ValidationError(
+                _('File size %(size).1f MB exceeds the limit of %(max)d MB.')
+                % {
+                    'size': file.size / (1024 * 1024),
+                    'max': self.max_size_mb,
+                }
+            )
+
+    def _validate_mime(self, file) -> None:
+        file.seek(0)
+        mime = magic.from_buffer(file.read(2048), mime=True)
+        file.seek(0)  # reset pointer so Django can continue saving the file
+
+        if mime not in self.allowed_types:
+            raise ValidationError(
+                _('File type "%(mime)s" is not allowed. Accepted: %(allowed)s.')
+                % {
+                    'mime': mime,
+                    'allowed': ', '.join(self.allowed_types),
+                }
+            )
+
+    def __eq__(self, other: object) -> bool:
+        """Required for stable migration comparison."""
+        return (
+            isinstance(other, MediaFileValidator)
+            and self.allowed_types == other.allowed_types
+            and self.max_size_mb == other.max_size_mb
+        )
+
+    def deconstruct(self) -> tuple:
+        """Required for Django to serialize this validator into migrations."""
+        return (
+            'core.validators.MediaFileValidator',
+            [],
+            {
+                'allowed_types': self.allowed_types,
+                'max_size_mb': self.max_size_mb,
+            },
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,19 +64,19 @@ services:
 #      --loglevel=info
 #      --scheduler django_celery_beat.schedulers:DatabaseScheduler
 #
-#  redis:
-#    image: redis:7-alpine
-#    volumes:
-#      - redis_data:/data
-#    restart: unless-stopped
-#    healthcheck:
-#      test: redis-cli --raw incr ping
-#      interval: 3s
-#      timeout: 30s
-#      retries: 5
-#      start_period: 2s
-#    networks:
-#      - web-net
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: redis-cli --raw incr ping
+      interval: 3s
+      timeout: 30s
+      retries: 5
+      start_period: 2s
+    networks:
+      - web-net
 #
 #  rabbitmq:
 #    image: rabbitmq:3-management-alpine
@@ -102,5 +102,5 @@ networks:
 volumes:
   postgres-data:
   django-static:
-#  redis_data:
+  redis_data:
 #  rabbitmq_data:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -66,10 +66,6 @@
           reverse_proxy web:8000
   }
   handle /admin/* {
-        # File upload size limit (10 MB)
-        request_body {
-            max_size 10MB
-        }
         reverse_proxy web:8000
   }
 

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -66,7 +66,11 @@
           reverse_proxy web:8000
   }
   handle /admin/* {
-          reverse_proxy web:8000
+        # File upload size limit (10 MB)
+        request_body {
+            max_size 10MB
+        }
+        reverse_proxy web:8000
   }
 
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get upgrade -y \
     gettext \
     git \
     libpq-dev \
+    libmagic1 \
   # Installing `tini` utility:
   # https://github.com/krallin/tini
   # Get architecture to download appropriate tini release:

--- a/poetry.lock
+++ b/poetry.lock
@@ -539,6 +539,25 @@ asgiref = ">=3.6"
 django = ">=4.2"
 
 [[package]]
+name = "django-csp"
+version = "3.8"
+description = "Django Content Security Policy support."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "django_csp-3.8-py3-none-any.whl", hash = "sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719"},
+    {file = "django_csp-3.8.tar.gz", hash = "sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+
+[package.extras]
+jinja2 = ["jinja2 (>=2.9.6)"]
+tests = ["jinja2 (>=2.9.6)", "pytest", "pytest-cov", "pytest-django", "pytest-ruff"]
+
+[[package]]
 name = "django-extensions"
 version = "4.1"
 description = "Extensions for Django"
@@ -586,6 +605,25 @@ files = [
 [package.dependencies]
 django = ">=5.1"
 typing-extensions = ">=4.0.1"
+
+[[package]]
+name = "django-redis"
+version = "5.4.0"
+description = "Full featured redis cache backend for Django."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "django-redis-5.4.0.tar.gz", hash = "sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42"},
+    {file = "django_redis-5.4.0-py3-none-any.whl", hash = "sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+redis = ">=3,<4.0.0 || >4.0.0,<4.0.1 || >4.0.1"
+
+[package.extras]
+hiredis = ["redis[hiredis] (>=3,!=4.0.0,!=4.0.1)"]
 
 [[package]]
 name = "djangorestframework"
@@ -1399,6 +1437,131 @@ files = [
 ]
 
 [[package]]
+name = "pillow"
+version = "11.3.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
+    {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e"},
+    {file = "pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6"},
+    {file = "pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f"},
+    {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94"},
+    {file = "pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0"},
+    {file = "pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac"},
+    {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d"},
+    {file = "pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149"},
+    {file = "pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d"},
+    {file = "pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b"},
+    {file = "pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3"},
+    {file = "pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51"},
+    {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c"},
+    {file = "pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a"},
+    {file = "pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214"},
+    {file = "pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635"},
+    {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b"},
+    {file = "pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d"},
+    {file = "pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71"},
+    {file = "pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada"},
+    {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
+    {file = "pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["pyarrow"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -1986,6 +2149,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-magic"
+version = "0.4.27"
+description = "File type identification using libmagic"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["main"]
+files = [
+    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
+    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -2534,4 +2709,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "2ae4ebed227be3a3a56bda0e1b7ab7263440fe8a291a8dbb9194dbabdaf7f403"
+content-hash = "1cfc27ead684648da2da9c4869b9d3ca312299422b5b70737344e6abf8fba944"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,17 @@ django-filter = "^25.2"
 pyyaml = "^6.0.3"
 drf-spectacular = "^0.29.0"
 django-cors-headers = "^4.9.0"
+django-csp = "^3.8"
 django-extensions = "^4.1"
 config = "^0.5.1"
+django-redis = "^5.4.0"
 dotenv-linter = "^0.7.0"
 gunicorn = "^23.0.0"
 yamllint = "^1.37.1"
 psycopg2 = "^2.9.11"
 django-modeltranslation = "^0.20.2"
+python-magic = "^0.4.27"
+Pillow = "^11.0"
 
 [tool.poetry.group.dev.dependencies]
 # Code quality and formatting
@@ -147,3 +151,4 @@ exclude_lines = [
     "class .*\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
 ]
+


### PR DESCRIPTION
## Политика безопасности

Реализован комплекс мер безопасности на уровне настроек, middleware и валидации.

### Что сделано

**HTTP-заголовки (production)**
- Content Security Policy через `django-csp` (script-src, img-src, frame-ancestors none и др.)
- HSTS
- `SECURE_PROXY_SSL_HEADER` для работы за Caddy
- Cookies: HttpOnly, SameSite=Lax, Secure, кастомные имена

**Защита Django Admin**
- `AdminLoginThrottleMiddleware`: 10 попыток/мин с одного IP → блокировка на 5 минут
- Логирование через `security` logger

**Валидация файлов**
- `MediaFileValidator`: проверка MIME по magic bytes (не по расширению)
- Предустановленные наборы: `IMAGE_TYPES`, `IMAGE_TYPES_EXTENDED`, `DOCUMENT_TYPES`
- Поддержка `__eq__` и `deconstruct` для корректной сериализации в миграциях

**Защита форм**
- `validate_no_html` — блокировка HTML/XSS в текстовых полях
- `validate_no_urls` — блокировка ссылок в сообщениях
- Honeypot-поле в `ContactSerializer` против ботов

**DRF**
- Ограничены разрешённые методы: только GET, POST, OPTIONS
- Настроены throttle rates для всех типов пользователей

