### PR TITLE
Исправлены тесты изображений проектов после перехода на ImageField

### DIFF
--- a/backend/tests/api/test_projects_list.py
+++ b/backend/tests/api/test_projects_list.py
@@ -94,7 +94,9 @@ def test_projects_list_returns_expected_card_fields(api_client, published_projec
     assert item['project_type'] == published_project.project_type.label
     assert item['tags'] == ['Social', 'Urban']
     assert item['year'] == str(published_project.year)
-    assert item['image'] == published_project.cover_image
+    assert item['image'] == (
+        f'http://testserver/media/{published_project.cover_image.name}'
+    )
 
 
 @pytest.mark.django_db

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -72,7 +72,7 @@ def published_project(project_type_architecture, tag_urban, tag_social):
         title='Central Park',
         description='Public space improvement project.',
         year=2024,
-        cover_image='https://example.com/central-park.jpg',
+        cover_image='projects/central-park/cover/central-park.jpg',
         project_type=project_type_architecture,
         is_published=True,
     )
@@ -87,7 +87,7 @@ def second_published_project(project_type_research, tag_social):
         title='City Research',
         description='Research about city mobility.',
         year=2023,
-        cover_image='https://example.com/city-research.jpg',
+        cover_image='projects/city-research/cover/city-research.jpg',
         project_type=project_type_research,
         is_published=True,
     )
@@ -102,7 +102,7 @@ def unpublished_project(project_type_architecture, tag_hidden):
         title='Secret Project',
         description='This project must stay hidden.',
         year=2025,
-        cover_image='https://example.com/secret.jpg',
+        cover_image='projects/secret-project/cover/secret.jpg',
         project_type=project_type_architecture,
         is_published=False,
     )


### PR DESCRIPTION
### Что изменено

- Обновлены тестовые значения `cover_image`: вместо внешних URL теперь используются относительные пути к media-файлам