### PR TITLE
Добавлен функционал гибкого заполнения контентного блока для проекта

### DIFF
--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -376,14 +376,6 @@ class ProjectContentBlock(models.Model):
             validate_string_list(self.string_list)
         except ValidationError as error:
             raise ValidationError({'string_list': error.messages}) from error
-        if self.variant == self.Variant.IMAGE_WITH_LIST and not self.string_list:
-            raise ValidationError({'string_list': _('Для варианта 1 требуется хотя бы один элемент списка.')})
-        if self.variant != self.Variant.IMAGE_WITH_LIST and self.string_list:
-            raise ValidationError({'string_list': _('Список тезисов допустим только для варианта 1.')})
-        if self.variant == self.Variant.TWO_IMAGES and not self.left_image:
-            raise ValidationError({'left_image': _('Для варианта 2 требуется второе изображение.')})
-        if self.variant != self.Variant.TWO_IMAGES and self.left_image:
-            raise ValidationError({'left_image': _('Второе изображение допустимо только для варианта 2.')})
 
     def save(self, *args, **kwargs):
         """Автоматически назначает порядок блока в пределах проекта."""

--- a/backend/tests/api/test_projects_detail.py
+++ b/backend/tests/api/test_projects_detail.py
@@ -61,6 +61,8 @@ def test_project_detail_hides_variant_specific_fields_for_list_block(
     list_block,
 ):
     """Проверяет, что для блока варианта IMAGE_WITH_LIST в ответе остаются только допустимые для него поля."""
+    list_block.left_image = 'https://example.com/hidden-left-image.jpg'
+    list_block.save()
     url = reverse('api:projects-detail', kwargs={'project_id': published_project.slug})
     response = api_client.get(url)
     assert response.status_code == 200
@@ -79,6 +81,8 @@ def test_project_detail_hides_variant_specific_fields_for_two_images_block(
     two_images_block,
 ):
     """Проверяет, что для блока варианта TWO_IMAGES в ответе остаются только допустимые для него поля."""
+    two_images_block.string_list = ['Hidden list item']
+    two_images_block.save()
     url = reverse('api:projects-detail', kwargs={'project_id': published_project.slug})
     response = api_client.get(url)
     assert response.status_code == 200
@@ -98,6 +102,9 @@ def test_project_detail_hides_variant_specific_fields_for_buttons_block(
     buttons_block,
 ):
     """Проверяет, что для блока варианта IMAGE_WITH_BUTTONS в ответе остаются только допустимые для него поля."""
+    buttons_block.left_image = 'https://example.com/hidden-left-image.jpg'
+    buttons_block.string_list = ['Hidden list item']
+    buttons_block.save()
     url = reverse('api:projects-detail', kwargs={'project_id': published_project.slug})
     response = api_client.get(url)
     assert response.status_code == 200

--- a/backend/tests/projects/test_models.py
+++ b/backend/tests/projects/test_models.py
@@ -134,8 +134,8 @@ def test_project_block_button_bulk_create_auto_sets_orders(buttons_block):
 
 
 @pytest.mark.django_db
-def test_content_block_with_list_variant_requires_string_list(published_project):
-    """Проверяет, что для блока варианта IMAGE_WITH_LIST список string_list обязателен."""
+def test_content_block_with_list_variant_allows_empty_string_list(published_project):
+    """Проверяет, что вариант IMAGE_WITH_LIST можно сохранить без списка тезисов."""
     block = ProjectContentBlock(
         project=published_project,
         variant=ProjectContentBlock.Variant.IMAGE_WITH_LIST,
@@ -146,14 +146,12 @@ def test_content_block_with_list_variant_requires_string_list(published_project)
         text='',
         accented_text='',
     )
-    with pytest.raises(ValidationError) as exc_info:
-        block.full_clean()
-    assert 'string_list' in exc_info.value.message_dict
+    block.full_clean()
 
 
 @pytest.mark.django_db
-def test_content_block_non_list_variant_forbids_string_list(published_project):
-    """Проверяет, что для вариантов, отличных от IMAGE_WITH_LIST, поле string_list запрещено."""
+def test_content_block_non_list_variant_allows_string_list(published_project):
+    """Проверяет, что нерелевантный список тезисов можно сохранить для другого варианта."""
     block = ProjectContentBlock(
         project=published_project,
         variant=ProjectContentBlock.Variant.TWO_IMAGES,
@@ -165,14 +163,12 @@ def test_content_block_non_list_variant_forbids_string_list(published_project):
         text='',
         accented_text='',
     )
-    with pytest.raises(ValidationError) as exc_info:
-        block.full_clean()
-    assert 'string_list' in exc_info.value.message_dict
+    block.full_clean()
 
 
 @pytest.mark.django_db
-def test_two_images_variant_requires_left_image(published_project):
-    """Проверяет, что для блока варианта TWO_IMAGES поле left_image обязательно."""
+def test_two_images_variant_allows_empty_left_image(published_project):
+    """Проверяет, что вариант TWO_IMAGES можно сохранить без второго изображения."""
     block = ProjectContentBlock(
         project=published_project,
         variant=ProjectContentBlock.Variant.TWO_IMAGES,
@@ -184,14 +180,12 @@ def test_two_images_variant_requires_left_image(published_project):
         text='',
         accented_text='',
     )
-    with pytest.raises(ValidationError) as exc_info:
-        block.full_clean()
-    assert 'left_image' in exc_info.value.message_dict
+    block.full_clean()
 
 
 @pytest.mark.django_db
-def test_non_two_images_variant_forbids_left_image(published_project):
-    """Проверяет, что для вариантов, отличных от TWO_IMAGES, поле left_image запрещено."""
+def test_non_two_images_variant_allows_left_image(published_project):
+    """Проверяет, что нерелевантное второе изображение можно сохранить для другого варианта."""
     block = ProjectContentBlock(
         project=published_project,
         variant=ProjectContentBlock.Variant.IMAGE_WITH_BUTTONS,
@@ -203,9 +197,7 @@ def test_non_two_images_variant_forbids_left_image(published_project):
         text='',
         accented_text='',
     )
-    with pytest.raises(ValidationError) as exc_info:
-        block.full_clean()
-    assert 'left_image' in exc_info.value.message_dict
+    block.full_clean()
 
 
 @pytest.mark.django_db
@@ -220,7 +212,7 @@ def test_content_block_bulk_create_validates_objects(published_project):
                     order=0,
                     title='Broken block',
                     image='https://example.com/broken.jpg',
-                    string_list=[],
+                    string_list='not-a-list',
                     text='',
                     accented_text='',
                 )


### PR DESCRIPTION
## Что изменено

- Ослаблена валидация `ProjectContentBlock`: теперь контентный блок может хранить все поля независимо от выбранного `variant`
- Убраны запреты на заполнение `string_list` для вариантов, отличных от `IMAGE_WITH_LIST`
- Убраны запреты на заполнение `left_image` для вариантов, отличных от `TWO_IMAGES`
- API-контракт сохранён: фронту по-прежнему отдаются только поля, релевантные выбранному варианту блока
- Обновлены тесты модели под новое поведение
- Усилены API-тесты: теперь они проверяют, что лишние сохранённые поля не попадают в ответ детальной страницы проекта


### Вопрос к обсуждению

- Если фронт использует index как React key, якорь, номер секции или визуальный идентификатор, это может дать некорректное поведение
- Стоит ли искусственно запретить одинаковый порядок у разных контентных блоков в пределах одного проекта?