### PR TITLE
Исправлена swagger документация ответа и переводов

### DIFF
--- a/backend/api/schemas/init_schemas.py
+++ b/backend/api/schemas/init_schemas.py
@@ -19,7 +19,9 @@ INIT_VIEW_SCHEMA = extend_schema(
                     'cookie_message': serializers.CharField(),
                     'cookie_button_text': serializers.CharField(),
                     'copyright': serializers.CharField(),
-                    'team_button_link': serializers.CharField(),
+                    'team_title': serializers.CharField(),
+                    'main_team_button_label': serializers.CharField(),
+                    'about_team_button_label': serializers.CharField(),
                     'legal_links': serializers.DictField(
                         child=serializers.CharField(),
                         help_text=_('Дополнительные юридические ссылки (Record<string, string>)'),
@@ -50,7 +52,9 @@ INIT_VIEW_SCHEMA = extend_schema(
                         'cookie_message': '<p>Мы используем технические cookie...</p>',
                         'cookie_button_text': 'Принять',
                         'copyright': '© 2026 Ambasada za Urbanizam',
-                        'team_button_link': '/contacts',
+                        'team_title': 'Команда',
+                        'main_team_button_label': 'Присоединиться к команде',
+                        'about_team_button_label': 'Подробнее о сообществе',
                         'legal_links': {},
                         'languages': [
                             {'code': 'ru', 'label': 'Russian'},

--- a/backend/locale/en/LC_MESSAGES/django.po
+++ b/backend/locale/en/LC_MESSAGES/django.po
@@ -417,10 +417,8 @@ msgid "Получение контента блока контактов"
 msgstr "Get contacts block content"
 
 #: backend/api/schemas/contact_schemas.py:31
-#, fuzzy
-#| msgid "Возвращает данные страницы \"О нас\" со всеми секциями."
 msgid "Возвращает телефон и адрес организации."
-msgstr "Returns \"About Us\" page data with all sections."
+msgstr "Returns the organization phone number and address."
 
 #: backend/api/schemas/home_shemas.py:6
 msgid "Данные главной страницы"
@@ -614,7 +612,7 @@ msgstr "The message is too long. It cannot exceed 600 characters."
 
 #: backend/contacts/constants.py:28
 msgid "Определяет активный блок контактных данных (должен быть только один)"
-msgstr "Specifies the active contact data block (there must be only one"
+msgstr "Specifies the active contact data block (there must be only one)."
 
 #: backend/contacts/constants.py:31
 msgid "Выбор соцсети."

--- a/backend/locale/ru/LC_MESSAGES/django.po
+++ b/backend/locale/ru/LC_MESSAGES/django.po
@@ -410,7 +410,7 @@ msgstr ""
 
 #: backend/api/schemas/contact_schemas.py:31
 msgid "Возвращает телефон и адрес организации."
-msgstr ""
+msgstr "Возвращает телефон и адрес организации."
 
 #: backend/api/schemas/home_shemas.py:6
 msgid "Данные главной страницы"
@@ -531,10 +531,12 @@ msgid ""
 "Возвращает локализованный текст политики конфиденциальности в формате HTML. "
 "Локализация зависит от переданного заголовка `Accept-Language`."
 msgstr ""
+"Возвращает локализованный текст политики конфиденциальности в формате HTML. "
+"Локализация зависит от переданного заголовка `Accept-Language`."
 
 #: backend/api/schemas/security_schemas.py:15
 msgid "Политика конфиденциальности не найдена"
-msgstr ""
+msgstr "Политика конфиденциальности не найдена"
 
 #: backend/api/schemas/users_schemas.py:8
 msgid "Список участников команды"
@@ -596,7 +598,7 @@ msgstr ""
 
 #: backend/contacts/constants.py:28
 msgid "Определяет активный блок контактных данных (должен быть только один)"
-msgstr ""
+msgstr "Определяет активный блок контактных данных (должен быть только один)."
 
 #: backend/contacts/constants.py:31
 msgid "Выбор соцсети."
@@ -665,7 +667,7 @@ msgstr ""
 
 #: backend/contacts/models.py:67
 msgid "Контактный телефон организации"
-msgstr ""
+msgstr "Контактный телефон организации"
 
 #: backend/contacts/models.py:71
 msgid "Адрес"
@@ -673,7 +675,7 @@ msgstr ""
 
 #: backend/contacts/models.py:72
 msgid "Адрес организации"
-msgstr ""
+msgstr "Адрес организации"
 
 #: backend/contacts/models.py:76
 msgid "Активно"
@@ -685,7 +687,7 @@ msgstr ""
 
 #: backend/contacts/models.py:96 backend/contacts/models.py:97
 msgid "Контактные данные"
-msgstr ""
+msgstr "Контактные данные"
 
 #: backend/contacts/models.py:133 backend/site_config/models.py:101
 #: backend/site_config/models.py:102
@@ -1369,31 +1371,31 @@ msgstr ""
 
 #: backend/security/admin.py:32 backend/security/models.py:9
 msgid "Текст политики"
-msgstr ""
+msgstr "Текст политики"
 
 #: backend/security/apps.py:9
 msgid "Полтика конфиденциальности"
-msgstr ""
+msgstr "Политика конфиденциальности"
 
 #: backend/security/constants.py:3
 msgid "Основной текст документа (поддерживает HTML)"
-msgstr ""
+msgstr "Основной текст документа (поддерживает HTML)"
 
 #: backend/security/models.py:10
 msgid "Дата последнего обновления"
-msgstr ""
+msgstr "Дата последнего обновления"
 
 #: backend/security/models.py:13 backend/security/models.py:14
 msgid "Политика конфиденциальности"
-msgstr ""
+msgstr "Политика конфиденциальности"
 
 #: backend/security/models.py:22
 msgid "Может существовать только одна запись политики конфиденциальности."
-msgstr ""
+msgstr "Может существовать только одна запись политики конфиденциальности."
 
 #: backend/security/models.py:34
 msgid "Текст политики..."
-msgstr ""
+msgstr "Текст политики..."
 
 #: backend/site_config/admin.py:135
 msgid "1. Основные и общие настройки"

--- a/backend/locale/sr_Cyrl/LC_MESSAGES/django.po
+++ b/backend/locale/sr_Cyrl/LC_MESSAGES/django.po
@@ -417,10 +417,8 @@ msgid "Получение контента блока контактов"
 msgstr "Преузимање садржаја блока контаката"
 
 #: backend/api/schemas/contact_schemas.py:31
-#, fuzzy
-#| msgid "Возвращает данные страницы \"О нас\" со всеми секциями."
 msgid "Возвращает телефон и адрес организации."
-msgstr "Враћа податке странице „О нама“ са свим секцијама."
+msgstr "Враћа телефон и адресу организације."
 
 #: backend/api/schemas/home_shemas.py:6
 msgid "Данные главной страницы"
@@ -614,7 +612,7 @@ msgstr "Порука је предугачка. Не може имати виш�
 
 #: backend/contacts/constants.py:28
 msgid "Определяет активный блок контактных данных (должен быть только один)"
-msgstr ""
+msgstr "Одређује активни блок контакт података (може постојати само један)."
 
 #: backend/contacts/constants.py:31
 msgid "Выбор соцсети."
@@ -703,10 +701,8 @@ msgid "Дата обновления"
 msgstr "Датум ажурирања"
 
 #: backend/contacts/models.py:96 backend/contacts/models.py:97
-#, fuzzy
-#| msgid "Контентный блок"
 msgid "Контактные данные"
-msgstr "Блок садржаја"
+msgstr "Контакт подаци"
 
 #: backend/contacts/models.py:133 backend/site_config/models.py:101
 #: backend/site_config/models.py:102

--- a/backend/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/backend/locale/sr_Latn/LC_MESSAGES/django.po
@@ -417,10 +417,8 @@ msgid "Получение контента блока контактов"
 msgstr "Preuzimanje sadržaja bloka kontakata"
 
 #: backend/api/schemas/contact_schemas.py:31
-#, fuzzy
-#| msgid "Возвращает данные страницы \"О нас\" со всеми секциями."
 msgid "Возвращает телефон и адрес организации."
-msgstr "Vraća podatke stranice „O nama“ sa svim sekcijama."
+msgstr "Vraća telefon i adresu organizacije."
 
 #: backend/api/schemas/home_shemas.py:6
 msgid "Данные главной страницы"
@@ -1476,7 +1474,7 @@ msgstr "Tekst politike"
 
 #: backend/security/apps.py:9
 msgid "Полтика конфиденциальности"
-msgstr "Polika privatnosti"
+msgstr "Politika privatnosti"
 
 #: backend/security/constants.py:3
 msgid "Основной текст документа (поддерживает HTML)"

--- a/backend/tests/site_config/test_init.py
+++ b/backend/tests/site_config/test_init.py
@@ -44,6 +44,10 @@ class InitViewTests(APITestCase):
         self.assertIn('languages', response.data)
         self.assertIn('socials', response.data)
         self.assertIn('copyright', response.data)
+        self.assertIn('team_title', response.data)
+        self.assertIn('main_team_button_label', response.data)
+        self.assertIn('about_team_button_label', response.data)
+        self.assertNotIn('team_button_link', response.data)
 
     def test_empty_relations(self):
         """Проверка корректного возврата данных при отсутствии связанных записей в БД."""


### PR DESCRIPTION
## Что сделано

- Актуализирована OpenAPI документация `GET /api/v1/init/` под фактический ответ API
- Из схемы и примера удалено поле `team_button_link`, которого нет в ответе
- В схему и пример добавлены поля `team_title`, `main_team_button_label`, `about_team_button_label`
- Исправлены переводы для контактов и новой модели политики конфиденциальности
- Убраны некорректные переводы, где описание контактов ссылалось на страницу “О нас”
- Исправлены пустые и ошибочные строки переводов для `ru`, `en`, `sr-Latn`, `sr-Cyrl`